### PR TITLE
Fix for some nil value Runtime error

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -91,11 +91,14 @@ minetest.register_on_punchnode(function(pos, node, player)
 		groups = groups.._.."="..v..", "
 	end
 
-	local tile = nodedef.tiles[1]
-	if type(tile) ~= "string" then
-		tile = nodedef.inventory_image or ""
-	else
-		tile = tile.."^[resize:16x16"
+	local tile = ""
+	if nodedef.tiles then
+		tile = nodedef.tiles[1]
+		if type(tile) ~= "string" then
+			tile = nodedef.inventory_image or ""
+		else
+			tile = tile.."^[resize:16x16"
+		end
 	end
 
 	local scale, groups_pos, texture_scale, texture_pos, desc_text


### PR DESCRIPTION
Fixes #1

I occasionally received a runtime error in punchinfos on_punchnode event:
```
2020-04-26 21:35:42: ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod '*builtin*' in callback node_on_punch(): ...test\minetest-5.2.0-win64\bin\..\mods\punchinfo\init.lua:94: attempt to index field 'tiles' (a nil value)
2020-04-26 21:35:42: ERROR[Main]: stack traceback:
2020-04-26 21:35:42: ERROR[Main]: 	...test\minetest-5.2.0-win64\bin\..\mods\punchinfo\init.lua:94: in function 'callback'
2020-04-26 21:35:42: ERROR[Main]: 	...netest\minetest-5.2.0-win64\bin\..\builtin\game\item.lua:518: in function <...netest\minetest-5.2.0-win64\bin\..\builtin\game\item.lua:511>
```
Looks like nodedef.tiles can occasionally be nil.